### PR TITLE
Add NAFLD Fibrosis Score (NFS)

### DIFF
--- a/src/scores/library.ts
+++ b/src/scores/library.ts
@@ -126,6 +126,7 @@ import { ScoreType } from '../types'
 import { korq } from './korq/korq'
 import { mlks } from './mlks/mlks'
 import { psqi } from './psqi/psqi'
+import { nafld_fibrosis } from './nafld_fibrosis/nafld_fibrosis'
 import { test_calculation } from './test_calculation/test_caculation'
 
 const createScoreLibrary = <T extends Record<string, ScoreType<any, any>>>(
@@ -215,6 +216,7 @@ export const ScoreLibrary = createScoreLibrary({
   mini_best_test,
   mfis,
   mlks,
+  nafld_fibrosis,
   mmse,
   moca,
   modified_caregiver_strain_index,

--- a/src/scores/nafld_fibrosis/README.md
+++ b/src/scores/nafld_fibrosis/README.md
@@ -1,0 +1,26 @@
+# NAFLD Fibrosis Score (NFS)
+
+## Overview
+The NAFLD Fibrosis Score estimates the risk of advanced liver fibrosis in patients with non-alcoholic fatty liver disease using clinical and laboratory parameters.
+
+## Inputs
+- Age (years)
+- BMI (kg/m²)
+- IFG/Diabetes (yes/no)
+- AST (U/L) [> 0]
+- ALT (U/L) [> 0]
+- Platelet count (×10⁹/L)
+- Albumin (g/dL)
+
+## Outputs
+- NFS_SCORE (number, rounded to 3 decimals)
+- NFS_CATEGORY (low / indeterminate / high)
+- NFS_LOW_CUTOFF_USED
+- NFS_HIGH_CUTOFF_USED
+
+## Interpretation
+- Age < 65: low if < −1.455; high if > 0.675; otherwise indeterminate
+- Age ≥ 65: low if < −0.12; high if > 0.675; otherwise indeterminate
+
+## Reference
+Angulo P et al., "The NAFLD fibrosis score: A noninvasive system that identifies liver fibrosis in patients with NAFLD", Hepatology, 2007.

--- a/src/scores/nafld_fibrosis/definition/index.ts
+++ b/src/scores/nafld_fibrosis/definition/index.ts
@@ -1,0 +1,2 @@
+export { NAFLD_FIBROSIS_INPUTS } from './nafld_fibrosis_inputs'
+export { NAFLD_FIBROSIS_OUTPUT } from './nafld_fibrosis_output'

--- a/src/scores/nafld_fibrosis/definition/nafld_fibrosis_inputs.ts
+++ b/src/scores/nafld_fibrosis/definition/nafld_fibrosis_inputs.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+import { ScoreInputSchemaType } from '../../../types'
+
+export const NAFLD_FIBROSIS_INPUTS = {
+  age: {
+    type: z.number().min(0),
+    label: { en: 'Age' },
+    unit: { en: 'years' },
+  },
+  bmi: {
+    type: z.number().min(0),
+    label: { en: 'BMI' },
+    unit: { en: 'kg/m2' },
+  },
+  ifg_or_diabetes: {
+    type: z.boolean(),
+    label: { en: 'Impaired fasting glucose or diabetes' },
+  },
+  ast: {
+    type: z.number().min(1),
+    label: { en: 'AST' },
+    unit: { en: 'U/L' },
+  },
+  alt: {
+    type: z.number().min(1),
+    label: { en: 'ALT' },
+    unit: { en: 'U/L' },
+  },
+  platelet: {
+    type: z.number().min(0),
+    label: { en: 'Platelet count' },
+    unit: { en: '×10^9/L' },
+  },
+  albumin: {
+    type: z.number().min(0),
+    label: { en: 'Albumin' },
+    unit: { en: 'g/dL' },
+  },
+} satisfies ScoreInputSchemaType

--- a/src/scores/nafld_fibrosis/definition/nafld_fibrosis_output.ts
+++ b/src/scores/nafld_fibrosis/definition/nafld_fibrosis_output.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+import { ScoreOutputSchemaType } from '../../../types'
+
+export const NAFLD_FIBROSIS_OUTPUT = {
+  NFS_SCORE: {
+    type: z.number(),
+    label: { en: 'NAFLD Fibrosis Score' },
+  },
+  NFS_CATEGORY: {
+    type: z.string(),
+    label: { en: 'Fibrosis category' },
+  },
+  NFS_LOW_CUTOFF_USED: {
+    type: z.number(),
+    label: { en: 'Low cutoff used' },
+  },
+  NFS_HIGH_CUTOFF_USED: {
+    type: z.number(),
+    label: { en: 'High cutoff used' },
+  },
+} satisfies ScoreOutputSchemaType

--- a/src/scores/nafld_fibrosis/nafld_fibrosis.test.ts
+++ b/src/scores/nafld_fibrosis/nafld_fibrosis.test.ts
@@ -1,0 +1,104 @@
+import { ZodError } from 'zod'
+import { Score } from '../../classes'
+import { ScoreLibrary } from '../library'
+import { nafld_fibrosis } from './nafld_fibrosis'
+
+const calculation = new Score(nafld_fibrosis)
+
+describe('NAFLD Fibrosis Score (NFS)', () => {
+  it('is registered in the ScoreLibrary', () => {
+    expect(ScoreLibrary).toHaveProperty('nafld_fibrosis')
+  })
+
+  it('calculates High case (platelets=176)', () => {
+    const out = calculation.calculate({
+      payload: {
+        age: 55,
+        bmi: 31.5,
+        ifg_or_diabetes: true,
+        ast: 60,
+        alt: 50,
+        platelet: 176,
+        albumin: 3.8,
+      },
+    })
+    expect(out.NFS_SCORE).toBeCloseTo(0.843, 3)
+    expect(out.NFS_CATEGORY).toBe('high')
+  })
+
+  it('calculates Indeterminate case (platelets=210)', () => {
+    const out = calculation.calculate({
+      payload: {
+        age: 55,
+        bmi: 31.5,
+        ifg_or_diabetes: true,
+        ast: 60,
+        alt: 50,
+        platelet: 210,
+        albumin: 3.8,
+      },
+    })
+    expect(out.NFS_SCORE).toBeCloseTo(0.401, 3)
+    expect(out.NFS_CATEGORY).toBe('indeterminate')
+  })
+
+  it('calculates Low bucket example', () => {
+    const out = calculation.calculate({
+      payload: {
+        age: 40,
+        bmi: 22,
+        ifg_or_diabetes: false,
+        ast: 25,
+        alt: 40,
+        platelet: 300,
+        albumin: 4.6,
+      },
+    })
+    expect(out.NFS_SCORE).toBeLessThan(-1.455)
+    expect(out.NFS_CATEGORY).toBe('low')
+  })
+
+  it('uses age ≥65 low cutoff −0.12', () => {
+    const base = {
+      bmi: 28,
+      ifg_or_diabetes: false,
+      ast: 30,
+      alt: 30,
+      platelet: 250,
+      albumin: 4.0,
+    }
+    const outUnder65 = calculation.calculate({ payload: { age: 64, ...base } })
+    const out65AndOver = calculation.calculate({ payload: { age: 65, ...base } })
+    expect(outUnder65.NFS_LOW_CUTOFF_USED).toBe(-1.455)
+    expect(out65AndOver.NFS_LOW_CUTOFF_USED).toBe(-0.12)
+  })
+
+  it('enforces AST/ALT > 0 via schema', () => {
+    expect(() =>
+      calculation.calculate({
+        payload: {
+          age: 40,
+          bmi: 22,
+          ifg_or_diabetes: false,
+          ast: 0,
+          alt: 30,
+          platelet: 200,
+          albumin: 4,
+        } as any,
+      }),
+    ).toThrow(ZodError)
+    expect(() =>
+      calculation.calculate({
+        payload: {
+          age: 40,
+          bmi: 22,
+          ifg_or_diabetes: false,
+          ast: 30,
+          alt: 0,
+          platelet: 200,
+          albumin: 4,
+        } as any,
+      }),
+    ).toThrow(ZodError)
+  })
+})

--- a/src/scores/nafld_fibrosis/nafld_fibrosis.ts
+++ b/src/scores/nafld_fibrosis/nafld_fibrosis.ts
@@ -1,0 +1,55 @@
+import { ScoreType } from '../../types'
+import { NAFLD_FIBROSIS_INPUTS, NAFLD_FIBROSIS_OUTPUT } from './definition'
+
+const HIGH_CUTOFF = 0.675
+const LOW_CUTOFF_UNDER_65 = -1.455
+const LOW_CUTOFF_65_AND_OVER = -0.12
+
+export const nafld_fibrosis: ScoreType<
+  typeof NAFLD_FIBROSIS_INPUTS,
+  typeof NAFLD_FIBROSIS_OUTPUT
+> = {
+  name: 'NAFLD Fibrosis Score (NFS)',
+  readmeLocation: __dirname,
+  inputSchema: NAFLD_FIBROSIS_INPUTS,
+  outputSchema: NAFLD_FIBROSIS_OUTPUT,
+  calculate: ({ data }) => {
+    const age = data.age
+    const bmi = data.bmi
+    const ifg = data.ifg_or_diabetes ? 1 : 0
+    const ast = data.ast
+    const alt = data.alt
+    const platelet = data.platelet
+    const albumin = data.albumin
+
+    const raw =
+      -1.675 +
+      0.037 * age +
+      0.094 * bmi +
+      1.13 * ifg +
+      0.99 * (ast / alt) -
+      0.013 * platelet -
+      0.66 * albumin
+
+    const lowCutoff = age >= 65 ? LOW_CUTOFF_65_AND_OVER : LOW_CUTOFF_UNDER_65
+    const highCutoff = HIGH_CUTOFF
+
+    const rounded = Math.round(raw * 1000) / 1000
+
+    let category: string
+    if (rounded < lowCutoff) {
+      category = 'low'
+    } else if (rounded > highCutoff) {
+      category = 'high'
+    } else {
+      category = 'indeterminate'
+    }
+
+    return {
+      NFS_SCORE: rounded,
+      NFS_CATEGORY: category,
+      NFS_LOW_CUTOFF_USED: lowCutoff,
+      NFS_HIGH_CUTOFF_USED: highCutoff,
+    }
+  },
+}


### PR DESCRIPTION
# Add NAFLD Fibrosis Score (NFS)

Requester: Jarrad Hicks (@baatax1)  
Link to Devin run: https://app.devin.ai/sessions/d1a8274bfc154da5a45ff47d368a357e

## Summary
Implements the NAFLD Fibrosis Score (NFS) calculation using the Awell Score TypeScript + zod pattern.

- Inputs (validated with zod):
  - age (years)
  - bmi (kg/m²)
  - ifg_or_diabetes (boolean)
  - ast (U/L, > 0)
  - alt (U/L, > 0)
  - platelet (×10⁹/L)
  - albumin (g/dL)

- Formula:
  NFS = -1.675 + 0.037*age + 0.094*bmi + 1.13*(ifg_or_diabetes?1:0) + 0.99*(AST/ALT) − 0.013*platelet − 0.66*albumin

- Outputs:
  - NFS_SCORE (number, rounded to 3 decimals)
  - NFS_CATEGORY ('low' | 'indeterminate' | 'high')
  - NFS_LOW_CUTOFF_USED (number)
  - NFS_HIGH_CUTOFF_USED (number)

- Thresholds:
  - High if > 0.675
  - Low if < -1.455 when age < 65
  - Low if < -0.12 when age ≥ 65
  - Otherwise indeterminate

## Files Added
- src/scores/nafld_fibrosis/definition/nafld_fibrosis_inputs.ts
- src/scores/nafld_fibrosis/definition/nafld_fibrosis_output.ts
- src/scores/nafld_fibrosis/definition/index.ts
- src/scores/nafld_fibrosis/nafld_fibrosis.ts
- src/scores/nafld_fibrosis/nafld_fibrosis.test.ts
- src/scores/nafld_fibrosis/README.md
- Registered in src/scores/library.ts

## Tests
- High case (platelets=176): expect NFS_SCORE ≈ 0.843, NFS_CATEGORY 'high'
- Indeterminate (platelets=210): expect NFS_SCORE ≈ 0.401, 'indeterminate'
- Low example: age 40, bmi 22, IFG/DM false, AST 25, ALT 40, platelets 300, albumin 4.6 → NFS < -1.455, 'low'
- Age ≥65 cutoff change: verifies NFS_LOW_CUTOFF_USED is -0.12 vs -1.455 when age < 65
- Schema: AST/ALT must be > 0 (throws ZodError if invalid)

Local run:
- Focused: yarn test src/scores/nafld_fibrosis/nafld_fibrosis.test.ts → passed
- Full suite: yarn test → passed locally (see run logs)

## How to Test Locally
- yarn install
- yarn test src/scores/nafld_fibrosis/nafld_fibrosis.test.ts
- Or run full suite: yarn test
